### PR TITLE
Keep the artifact name consistent across releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Release and GitHub Actions changes 🛠
+      labels:
+        - release-improvement
+        - github-actions
+    - title: Exciting New Features 🎉
+      labels:
+        - new-feature
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,9 +15,12 @@ jobs:
       - name: Build artifact
         shell: pwsh
         run: |
-          mkdir output
+          $tag = '${{ github.event.ref }}'.Replace('refs/tags/', '')
+          $zipDirectory = "GetMoarFediverse-$($tag)"
+
+          mkdir $tag
           mkdir artifact
-          $outputPath = Join-Path (Pwd) output
+          $outputPath = Join-Path (Pwd) $zipDirectory
           $srcPath = Join-Path (Pwd) src
 
           $uid = sh -c 'id -u'
@@ -25,16 +28,15 @@ jobs:
 
           docker run -v "$($outputPath):/var/output" -v "$($srcPath):/var/src" mcr.microsoft.com/dotnet/sdk:6.0.403-alpine3.16 ash -c "dotnet publish -r ${{ matrix.runtime }} --self-contained -p:PublishTrimmed=true -p:PublishSingleFile=true -c Release /var/src/GetMoarFediverse.csproj -o /var/output && chown -R $($uid):$($gid) /var/output"
 
-          $tag = '${{ github.event.ref }}'.Replace('refs/tags/', '')
-
-          Push-Location output
+          Push-Location $outputPath
           chmod +r *
           chmod +x GetMoarFediverse || true
+          Pop-Location
 
           if ('${{ matrix.runtime }}'.StartsWith('win-')) {
-            Compress-Archive -Path * -DestinationPath "../artifact/GetMoarFediverse_$($tag)_${{ matrix.runtime }}.zip"
+            Compress-Archive -Path $zipDirectory -DestinationPath "artifact/GetMoarFediverse_${{ matrix.runtime }}.zip"
           } else {
-            tar -czf ../artifact/GetMoarFediverse_$($tag)_${{ matrix.runtime }}.tgz *
+            tar -czf artifact/GetMoarFediverse_${{ matrix.runtime }}.tgz $zipDirectory
           }
           
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
This will let me have a stable link to the latest release.